### PR TITLE
toString the stdout/err buffer in spawnPromise

### DIFF
--- a/child-process-promise.js
+++ b/child-process-promise.js
@@ -16,8 +16,12 @@ var childProcess = require('child_process'),
 		'use strict';
 		return new Promise(function (resolve, reject) {
 			var process = childProcess.spawn(command, options);
-			process.stdout.on('data', console.log);
-			process.stderr.on('data', console.error);
+			process.stdout.on('data', function (buffer) {
+				console.log(buffer.toString());
+			});
+			process.stderr.on('data', function (buffer) {
+				console.error(buffer.toString());
+			});
 			process.on('close', function (code) {
 				if (code !== 0) {
 					reject(code);


### PR DESCRIPTION
.toString on a buffer will render the text in a human-readable form. This commit means that if pandoc prints an error, you'll be able to read the error in cloudwatch

Fixes #1
