### PR TITLE
Fix makefile, Now looks for Makefile_Pandoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ bash:
 	$(DOCKER) $(MOUNTS) --entrypoint /bin/bash -t $(DOCKER_IMAGE)
 
 all: build result cache 
-	$(DOCKER) $(MOUNTS) --entrypoint /usr/bin/make -t $(DOCKER_IMAGE) TARGET_DIR=$(TARGET) -f ../Makefile_ImageMagick $@
+	$(DOCKER) $(MOUNTS) --entrypoint /usr/bin/make -t $(DOCKER_IMAGE) TARGET_DIR=$(TARGET) -f ../Makefile_Pandoc $@
 
 
 STACK_NAME ?= pandoc-layer 


### PR DESCRIPTION
Currently, the Makefile looks for `Makefile_ImageMagick` which causes the following error:

`make: ../Makefile_ImageMagick: No such file or directory`

this is a simple fix 😄 